### PR TITLE
Fixed typographical error, changed adminstration to administration in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Beaneditor never use UPDATE or DELETE, so don't allow those actions.
 3. Edit settings.php_template and .htaccess_template accordingly to your db, and
 rename the files to settings.php and .htaccess
 
-4. If you want to password protect the adminstration pages, use .htpasswd and 
+4. If you want to password protect the administration pages, use .htpasswd and 
 put .htaccess files in the folders you want to protect, probably in:
    
 	./admin/  


### PR DESCRIPTION
@hannesmannerheim, I've corrected a typographical error in the documentation of the [beaneditor](https://github.com/hannesmannerheim/beaneditor) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
